### PR TITLE
Remove `docassemble/__init__.py` and update setup.py

### DIFF
--- a/docassemble/__init__.py
+++ b/docassemble/__init__.py
@@ -1,2 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)
-

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from setuptools import setup, find_packages
+from setuptools import setup, find_namespace_packages
 from fnmatch import fnmatchcase
 from distutils.util import convert_path
 
@@ -52,8 +52,7 @@ setup(name='docassemble.GrievanceHearingRequest',
       author_email='john.brandt@su.suffolk.edu',
       license='The MIT License',
       url='https://courtformsonline.org',
-      packages=find_packages(),
-      namespace_packages=['docassemble'],
+      packages=find_namespace_packages(),
       install_requires=['docassemble.AssemblyLine>=3.1.0'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/GrievanceHearingRequest/', package='docassemble.GrievanceHearingRequest'),


### PR DESCRIPTION

All to make sure that our docassemble packages will work with pip / setuptools into the future.

There are few errors that pop up when installing packages on docassemble:

```
UserWarning: pkg_resources is deprecated as an API. See [https://setuptools.pypa.io/en/latest/pkg_resources.html.](https://setuptools.pypa.io/en/latest/pkg_resources.html.) The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
```

```
The namespace_packages parameter is deprecated.

Please replace its usage with implicit namespaces (PEP 420).
```

```
Usage of dash-separated 'description-file' will not be supported in future
versions. Please use the underscore name 'description_file' instead.
```

## How this change was made

Selected repos that already had a `docassemble/__init__.py` file.

Ran:

```bash
gh repo list --limit 450 --json nameWithOwner --source SuffolkLITLab | jq -r '.[] .nameWithOwner' > repos.txt

turbolift foreach -- rm docassemble/__init__.py
```

Then:

* Manually removed repos where the command failed

Then, using VS Code search-replace:

* replaced `find_packages` with `find_namespace_packages` in `setup.py`.
* Removed the `namespace_package=['docassemble'],` param in the `setup.py`.
* `description-file` to `description_file`


<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>